### PR TITLE
Added missing formats to ImageMagick

### DIFF
--- a/net.fasterland.converseen.json
+++ b/net.fasterland.converseen.json
@@ -301,7 +301,7 @@
                     "commit": "10ad43dc3e5113fa1969a55583a080c5a6a23f65",
                     "x-checker-data": {
                         "type": "git",
-                        "tag-pattern": "^([\\d.-]+)$"
+                        "_tag-pattern": "^([\\d.-]+)$"
                     }
                 }
             ],

--- a/net.fasterland.converseen.json
+++ b/net.fasterland.converseen.json
@@ -7,25 +7,301 @@
     "rename-appdata-file": "converseen.appdata.xml",
     "finish-args": [
         "--device=dri",
+        "--filesystem=xdg-pictures",
+        "--filesystem=/media",
+        "--filesystem=/run/media",
+        "--filesystem=home",
         "--share=ipc",
+        "--share=network",
+        "--socket=cups",
         "--socket=fallback-x11",
         "--socket=wayland"
     ],
+    "cleanup": [
+    "/doc",
+    "/include",
+    "/lib/cmake",
+    "/lib/libexec",
+    "/lib/pkgconfig",
+    "/bin/wmf*",
+    "/bin/libwmf-*",
+    "/man",
+    "/share/doc",
+    "/share/man",
+    "/share/pkgconfig",
+    "*.a"
+    ],
     "modules": [
+    {
+            "name": "libheif",
+            "config-opts": [
+                "--disable-gdk-pixbuf"
+            ],
+            "cleanup": [
+                "/bin",
+                "/share/thumbnailers"
+            ],
+            "modules": [
+                {
+                    "name": "libde265",
+                    "config-opts": [
+                        "--disable-dec265",
+                        "--disable-encoder",
+                        "--disable-sherlock265"
+                    ],
+                    "cleanup": [
+                        "/bin"
+                    ],
+                    "sources": [
+                        {
+                            "type": "archive",
+                            "url": "https://github.com/strukturag/libde265/releases/download/v1.0.11/libde265-1.0.11.tar.gz",
+                            "sha256": "2f8f12cabbdb15e53532b7c1eb964d4e15d444db1be802505e6ac97a25035bab",
+                            "x-checker-data": {
+                                "type": "anitya",
+                                "project-id": 11239,
+                                "stable-only": true,
+                                "url-template": "https://github.com/strukturag/libde265/releases/download/v$version/libde265-$version.tar.gz"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "libx265",
+                    "buildsystem": "cmake",
+                    "subdir": "source",
+                    "config-opts": [
+                        "-DEXTRA_LIB='libx265-10.a;libx265-12.a'",
+                        "-DEXTRA_LINK_FLAGS=-L.",
+                        "-DLINKED_10BIT=ON",
+                        "-DLINKED_12BIT=ON"
+                    ],
+                    "cleanup": [
+                        "/bin"
+                    ],
+                    "sources": [
+                        {
+                            "type": "archive",
+                            "url": "https://bitbucket.org/multicoreware/x265_git/downloads/x265_3.5.tar.gz",
+                            "sha256": "e70a3335cacacbba0b3a20ec6fecd6783932288ebc8163ad74bcc9606477cae8",
+                            "x-checker-data": {
+                                "type": "anitya",
+                                "project-id": 7275,
+                                "stable-only": true,
+                                "url-template": "https://bitbucket.org/multicoreware/x265_git/downloads/x265_$version.tar.gz"
+                            }
+                        },
+                        {
+                            "type": "shell",
+                            "commands": [
+                                "ln -s ${FLATPAK_DEST}/lib/libx265-10.a",
+                                "ln -s ${FLATPAK_DEST}/lib/libx265-12.a",
+                                "rm -fr ${FLATPAK_DEST}/lib/libx265.so*"
+                            ]
+                        }
+                    ],
+                    "modules": [
+                        {
+                            "name": "libx265-10bpc",
+                            "buildsystem": "cmake",
+                            "subdir": "source",
+                            "config-opts": [
+                                "-DHIGH_BIT_DEPTH=ON",
+                                "-DEXPORT_C_API=OFF",
+                                "-DENABLE_SHARED=OFF",
+                                "-DENABLE_CLI=OFF",
+                                "-DENABLE_ASSEMBLY=OFF"
+                            ],
+                            "sources": [
+                                {
+                                    "type": "archive",
+                                    "url": "https://bitbucket.org/multicoreware/x265_git/downloads/x265_3.5.tar.gz",
+                                    "sha256": "e70a3335cacacbba0b3a20ec6fecd6783932288ebc8163ad74bcc9606477cae8",
+                                    "x-checker-data": {
+                                        "type": "anitya",
+                                        "project-id": 7275,
+                                        "stable-only": true,
+                                        "url-template": "https://bitbucket.org/multicoreware/x265_git/downloads/x265_$version.tar.gz"
+                                    }
+                                }
+                            ],
+                            "post-install": [
+                                "mv ${FLATPAK_DEST}/lib/libx265.a ${FLATPAK_DEST}/lib/libx265-10.a"
+                            ]
+                        },
+                        {
+                            "name": "libx265-12bpc",
+                            "buildsystem": "cmake",
+                            "subdir": "source",
+                            "config-opts": [
+                                "-DHIGH_BIT_DEPTH=ON",
+                                "-DEXPORT_C_API=OFF",
+                                "-DENABLE_SHARED=OFF",
+                                "-DENABLE_CLI=OFF",
+                                "-DENABLE_ASSEMBLY=OFF",
+                                "-DMAIN12=ON"
+                            ],
+                            "sources": [
+                                {
+                                    "type": "archive",
+                                    "url": "https://bitbucket.org/multicoreware/x265_git/downloads/x265_3.5.tar.gz",
+                                    "sha256": "e70a3335cacacbba0b3a20ec6fecd6783932288ebc8163ad74bcc9606477cae8",
+                                    "x-checker-data": {
+                                        "type": "anitya",
+                                        "project-id": 7275,
+                                        "stable-only": true,
+                                        "url-template": "https://bitbucket.org/multicoreware/x265_git/downloads/x265_$version.tar.gz"
+                                    }
+                                }
+                            ],
+                            "post-install": [
+                                "mv ${FLATPAK_DEST}/lib/libx265.a ${FLATPAK_DEST}/lib/libx265-12.a"
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/strukturag/libheif/releases/download/v1.15.1/libheif-1.15.1.tar.gz",
+                    "sha256": "28d5a376fe7954d2d03453f983aaa0b7486f475c27c7806bda31df9102325556",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 64439,
+                        "stable-only": true,
+                        "url-template": "https://github.com/strukturag/libheif/releases/download/v$version/libheif-$version.tar.gz"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "libraw",
+            "config-opts": [
+                "--disable-examples",
+                "--disable-jasper",
+                "--disable-static",
+                "--enable-jpeg",
+                "--enable-lcms",
+                "--enable-openmp"
+            ],
+            "cleanup": [
+                "/share/doc"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://www.libraw.org/data/LibRaw-0.21.1.tar.gz",
+                    "sha256": "630a6bcf5e65d1b1b40cdb8608bdb922316759bfb981c65091fec8682d1543cd"
+                }
+            ]
+        },
+        {
+            "name": "libwmf",
+            "config-opts": [
+                "--disable-static",
+                "--disable-dependency-tracking"
+            ],
+            "cleanup": [
+                "/share/doc",
+                "/bin"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/caolanm/libwmf/archive/refs/tags/v0.2.12.tar.gz",
+                    "sha512": "9280851e560becc91546906b911e0c59a1abd690e10680f6d94a335d66aeaec5eb12ccf2214ee7af2a15729a7b5f8b906022822399b4e2bc12c75a2d75748cab",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 230209,
+                        "stable-only": true,
+                        "url-template": "https://github.com/caolanm/libwmf/archive/refs/tags/v$version.tar.gz"
+                    }
+                },
+                {
+                    "type": "patch",
+                    "path": "patches/libwmf-ft2.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "patches/libwmf-autoheader.patch"
+                },
+                {
+                    "type": "shell",
+                    "commands": [
+                        "cp -p /usr/share/automake-*/config.{sub,guess} .",
+                        "autoreconf -vfi"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "ghostscript",
+            "config-opts": [
+                "--disable-cups"
+            ],
+            "make-args": [
+                "so"
+            ],
+            "make-install-args": [
+                "soinstall"
+            ],
+            "cleanup": [
+                "/share/ghostscript/10.0.0/doc/",
+                "/share/ghostscript/10.0.0/examples",
+                "/bin"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs1000/ghostscript-10.0.0.tar.gz",
+                    "sha256": "a57764d70caf85e2fc0b0f59b83b92e25775631714dcdb97cc6e0cea414bb5a3",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 1157,
+                        "stable-only": true,
+                        "url-template": "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs$major$minor$patch/ghostscript-$version.tar.gz"
+                    }
+                },
+                {
+                    "type": "shell",
+                    "commands": [
+                        "cp -p /usr/share/automake-*/config.{sub,guess} freetype/builds/unix/",
+                        "cp -p /usr/share/automake-*/config.{sub,guess} ijs/",
+                        "cp -p /usr/share/automake-*/config.{sub,guess} jpeg/",
+                        "cp -p /usr/share/automake-*/config.{sub,guess} libpng/",
+                        "cp -p /usr/share/automake-*/config.{sub,guess} lcms2mt/",
+                        "cp -p /usr/share/automake-*/config.{sub,guess} tiff/config/",
+                        "rm -rf libpng/pngread.c"
+                    ]
+                }
+            ]
+        },
         {
             "name": "imagemagick",
             "config-opts": [
-                "--disable-static"
+                "--disable-static",
+                "--enable-shared",
+                "--enable-hdri",
+                "--without-perl",
+                "--with-gslib=yes",
+                "--with-openjp2",
+                "--with-wmf",
+                "--without-gvc",
+                "--with-djvu",
+                "--without-dps",
+                "--without-fpx",
+                "--with-heic=yes"
             ],
             "sources": [
                 {
                     "type": "git",
                     "url": "https://github.com/ImageMagick/ImageMagick",
-                    "tag": "7.0.7.7",
-                    "commit": "e12602b39b5e778240d286b6f9bbbc0fe3fb26c5",
+                    "tag": "7.1.1-4",
+                    "commit": "10ad43dc3e5113fa1969a55583a080c5a6a23f65",
                     "x-checker-data": {
                         "type": "git",
-                        "_tag-pattern": "^([\\d.-]+)$"
+                        "tag-pattern": "^([\\d.-]+)$"
                     }
                 }
             ],
@@ -33,7 +309,7 @@
                 "/include",
                 "/share/doc",
                 "/lib/*.la",
-                "/bin/{animate,compare,composite,conjure,display,identify,import,magick,magick-script,mogrify,montage,stream}"
+                "/bin"
             ]
         },
         {

--- a/patches/libwmf-autoheader.patch
+++ b/patches/libwmf-autoheader.patch
@@ -1,0 +1,116 @@
+From 398c41a68854fbf83e8db7ccc3133612015acfc4 Mon Sep 17 00:00:00 2001
+From: niclet <nicolas.creplet@gmail.com>
+Date: Sat, 16 Oct 2021 16:13:21 +0200
+Subject: [PATCH] Fix autoheader issues
+
+---
+ configure.ac | 28 ++++++++++++++--------------
+ 1 file changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 6e08583..3bfd86e 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -146,7 +146,7 @@ dnl Checks for header files.
+ AC_HEADER_STDC
+ AC_CHECK_HEADERS(time.h)
+ AC_CHECK_HEADER(unistd.h,[
+-	AC_DEFINE(HAVE_UNISTD_H)
++	AC_DEFINE([HAVE_UNISTD_H], [], [Header unistd.h is available])
+ 	GD_DEFS="$GD_DEFS -DHAVE_UNISTD_H"
+ ])
+ 
+@@ -174,13 +174,13 @@ AC_CHECK_FUNCS(vsnprintf,,check_for_vsnprintf=yes)
+ 
+ if [ test "x$check_for_vsnprintf" = "xyes" ]; then
+ 	AC_CHECK_FUNC(_vsnprintf,[
+-		AC_DEFINE(HAVE_VSNPRINTF)
+-		AC_DEFINE(vsnprintf,_vsnprintf)
++		AC_DEFINE([HAVE_VSNPRINTF], [], [Function _vsnprintf is available])
++		AC_DEFINE([vsnprintf], [_vsnprintf], [Use _vsnprintf instead of vsnprintf])
+ 	],[	dnl Hmm. On the off-chance, check for vsnprintf in libdb.
+ 		dnl This should, hopefully, solve the problem with Tru64 4.x
+ 		dnl which is incompatible with trio (the latter's fault).
+ 		AC_CHECK_LIB(db,vsnprintf,[
+-			AC_DEFINE(HAVE_VSNPRINTF)
++			AC_DEFINE([HAVE_VSNPRINTF], [], [Function vsnprintf is available])
+ 			WMF_LIBFLAGS="$WMF_LIBFLAGS -ldb"
+ 		],[	require_trio=yes
+ 		])
+@@ -192,8 +192,8 @@ AC_CHECK_FUNCS(snprintf,,check_for_snprintf=yes)
+ 
+ if [ test "x$check_for_snprintf" = "xyes" ]; then
+ 	AC_CHECK_FUNC(_snprintf,[
+-		AC_DEFINE(HAVE_SNPRINTF)
+-		AC_DEFINE(snprintf,_snprintf)
++		AC_DEFINE([HAVE_SNPRINTF], [], [Function _snprintf is available])
++		AC_DEFINE([snprintf], [_snprintf], [Use _snprintf instead of snprintf])
+ 	])
+ fi
+ 
+@@ -204,7 +204,7 @@ if [ test "x$check_for_vfscanf" = "xyes" ]; then
+ 	AC_MSG_CHECKING(for vfscanf in stdio.h)
+ 	AC_EGREP_HEADER(vfscanf,stdio.h,[
+ 		AC_MSG_RESULT(yes)
+-		AC_DEFINE(HAVE_VFSCANF)
++		AC_DEFINE([HAVE_VFSCANF], [], [Function vfscanf is available])
+ 	],[	AC_MSG_RESULT(no)
+ 	])
+ fi
+@@ -235,7 +235,7 @@ if test $LIBWMF_BUILDSTYLE = lite; then
+ fi # $LIBWMF_BUILDSTYLE = lite
+ 
+ if [ test $libwmf_layers = no ]; then
+-	AC_DEFINE(WITHOUT_LAYERS,1)
++	AC_DEFINE([WITHOUT_LAYERS], [1], [Don't use layers])
+ fi
+ 
+ AM_CONDITIONAL(LIBWMF_OPT_MODULES,[ test $libwmf_layers = modules ])
+@@ -361,9 +361,9 @@ if test $libwmf_xml = libxml2 -o $libwmf_xml = unknown; then
+ fi
+ 
+ if test $libwmf_xml = expat; then
+-	AC_DEFINE(HAVE_EXPAT)
++	AC_DEFINE([HAVE_EXPAT], [], [Use expat as libwmf_xml])
+ elif test $libwmf_xml = libxml2; then
+-	AC_DEFINE(HAVE_LIBXML2)
++	AC_DEFINE([HAVE_LIBXML2], [], [Use libxml2 as  libwmf_xml])
+ else
+ 	libwmf_xml=none
+ 	WMF_XML_CFLAGS=""
+@@ -524,7 +524,7 @@ AC_CHECK_HEADER(png.h,[
+ ],[	AC_MSG_ERROR(* * * unable to find "png.h" which is required by libwmf * * *)
+ ])
+ 
+-AC_DEFINE(HAVE_LIBPNG)
++AC_DEFINE([HAVE_LIBPNG], [], [Library libpng is available])
+ GD_DEFS="$GD_DEFS -DHAVE_LIBPNG"
+ 
+ fi # $LIBWMF_BUILDSTYLE = heavy
+@@ -567,7 +567,7 @@ if [ test "$search_for_jpeg" != "no" ]; then
+ 			else
+ 				WMF_JPEG_LDFLAGS="-ljpeg"
+ 			fi
+-			AC_DEFINE(HAVE_LIBJPEG)
++			AC_DEFINE([HAVE_LIBJPEG], [], [Library libjpeg is available])
+ 			GD_DEFS="$GD_DEFS -DHAVE_LIBJPEG"
+ 			libwmf_gd_jpeg=yes
+ 		])
+@@ -649,7 +649,7 @@ if [ test "$search_for_gd" != "no" ]; then
+ fi
+ 
+ if [ test "x$libwmf_gd" != "xnone" ]; then
+-	AC_DEFINE(HAVE_GD,1)
++	AC_DEFINE([HAVE_GD], [1], [Library gd is available])
+ 	build_gd_layer=yes
+ else
+ 	build_gd_layer=no
+@@ -711,7 +711,7 @@ if [ test "$search_for_plot" != "no" ]; then
+ 				else
+ 					WMF_PLOT_LDFLAGS="$LIBPLOT_LIBS"
+ 				fi
+-				AC_DEFINE(HAVE_LIBPLOT)
++				AC_DEFINE([HAVE_LIBPLOT], [], [Library libplot is available])
+ 				libwmf_plot=maybe
+ 			else
+ 				AC_MSG_ERROR(* * * sorry - unable to link against libplot * * *)

--- a/patches/libwmf-ft2.patch
+++ b/patches/libwmf-ft2.patch
@@ -1,0 +1,24 @@
+diff --git a/configure.ac b/configure.ac
+index 3bfd86e..3f2de0b 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -418,15 +418,10 @@ fi
+ CPPFLAGS="$freetype_cflags $CPPFLAGS"
+ LDFLAGS="$LDFLAGS $freetype_libs"
+ 
+-AC_CHECK_LIB(freetype,FT_Init_FreeType,[
+-	WMF_FT_LDFLAGS="$freetype_libs"
+-],[	AC_MSG_ERROR([* * * freetype(2) is required * * *])
+-])
+-AC_CHECK_HEADER(ft2build.h,[
+-	WMF_FT_CFLAGS="$freetype_cflags"
+-	WMF_FT_CONFIG_CFLAGS="$freetype_cflags"
+-],[	AC_MSG_ERROR([* * * freetype(2) is required * * *])
+-])
++PKG_CHECK_MODULES(FT2, freetype2)
++WMF_FT_LDFLAGS=$FT2_LIBS
++WMF_FT_CFLAGS=$FT2_CFLAGS
++WMF_FT_CONFIG_CFLAGS=$FT2_CFLAGS
+ 
+ GD_DEFS="$GD_DEFS -DHAVE_LIBFREETYPE"
+ 


### PR DESCRIPTION
Added missing formats to ImageMagick:

- HEIC/HEIF: libheif, libde265, libx265, libx265-10bpc, libx265-12bpc
- RAW formats: libraw
- WMF: libwmf
- PDF: Ghostscript library